### PR TITLE
Feat: Add function to get shareable link

### DIFF
--- a/main/src/scripts/components/app/App.jsx
+++ b/main/src/scripts/components/app/App.jsx
@@ -139,6 +139,14 @@ class App extends Component {
     }
   }
 
+  // Function that creates a shareable link
+  getShareableLink () {
+    chrome.identity.getProfileUserInfo((data) => {
+      const name = data.email.split('@')[0];
+      console.log(`Shareable link: http://www.baseUrlOfMapMarklet/${name}`);
+    });
+  }
+
   render () {
     if (!this.props.loaded) {
       return (<div>Loading...</div>);
@@ -149,7 +157,7 @@ class App extends Component {
         <div ref="map" className="mapStyle">
         </div>
         <div className="overlay">
-          <a href="#"><ShareBt size={40} color="#C54E4E"/></a>
+          <a href="#" onClick={this.getShareableLink}><ShareBt size={40} color="#C54E4E"/></a>
         </div>
       </div>
 


### PR DESCRIPTION
Added logic to get the shareable link

This exists in a new function called `getShareableLink`. At the moment, this function is logging the shareable link into the console but ideally, we want to display that information on top of the map.

The current logic can be used as a building block to get that done